### PR TITLE
DIN 5008 Anpassungen

### DIFF
--- a/Abkuerzungen.tex
+++ b/Abkuerzungen.tex
@@ -8,7 +8,9 @@
 % Hinweis: allgemein bekannte IT-Begriffe wie Datenbank oder Programmiersprache müssen nicht erläutert werden,
 %          aber ggfs. Fachbegriffe aus der Domäne des Prüflings (z.B. Versicherung)
 
-\begin{acronym}
+% Die Option (in den eckigen Klammern) enthält das längste Label oder
+% einen Platzhalter der die Breite der linken Spalte bestimmt.
+\begin{acronym}[WWWWW]
 	\acro{AO}{\textsc{Alte Oldenburger} Krankenversicherung AG}
 	\acro{API}{Application Programming Interface}
 	\acro{CSS}{Cascading Style Sheets}

--- a/Allgemein/Packages.tex
+++ b/Allgemein/Packages.tex
@@ -29,6 +29,7 @@
 \graphicspath{{Bilder/}} % hier liegen die Bilder des Dokuments
 
 % Sonstiges --------------------------------------------------------------------
+\usepackage[titles]{tocloft} % Inhaltsverzeichnis DIN 5008 gerecht einrücken
 \usepackage{amsmath,amsfonts} % Befehle aus AMSTeX für mathematische Symbole
 \usepackage{enumitem} % anpassbare Enumerates/Itemizes
 \usepackage{xspace} % sorgt dafür, dass Leerzeichen hinter parameterlosen Makros nicht als Makroendezeichen interpretiert werden

--- a/Allgemein/Seitenstil.tex
+++ b/Allgemein/Seitenstil.tex
@@ -26,6 +26,31 @@
 \cfoot{}
 \ofoot{\pagemark}
 
+% Überschriften nach DIN 5008 in einer Fluchtlinie
+% ------------------------------------------------------------------------------
+
+% Abstand zwischen Nummerierung und Überschrift definieren
+% > Schön wäre hier die dynamische Berechnung des Abstandes in Abhängigkeit
+% > der Verschachtelungstiefe des Inhaltsverzeichnisses
+\newcommand{\headingSpace}{1.5cm}
+
+% Abschnittsüberschriften im selben Stil wie beim Inhaltsverzeichnis einrücken
+\renewcommand*{\othersectionlevelsformat}[3]{
+  \makebox[\headingSpace][l]{#3\autodot}
+}
+
+% Für die Einrückung wird das Paket tocloft benötigt
+%\cftsetindents{chapter}{0.0cm}{\headingSpace}
+\cftsetindents{section}{0.0cm}{\headingSpace}
+\cftsetindents{subsection}{0.0cm}{\headingSpace}
+\cftsetindents{subsubsection}{0.0cm}{\headingSpace}
+\cftsetindents{figure}{0.0cm}{\headingSpace}
+\cftsetindents{table}{0.0cm}{\headingSpace}
+
+
+% Allgemeines
+% ------------------------------------------------------------------------------
+
 \onehalfspacing % Zeilenabstand 1,5 Zeilen
 \frenchspacing % erzeugt ein wenig mehr Platz hinter einem Punkt 
 

--- a/Projektdokumentation.tex
+++ b/Projektdokumentation.tex
@@ -11,7 +11,8 @@
 	toc=listof, % Abbildungsverzeichnis sowie Tabellenverzeichnis in das Inhaltsverzeichnis aufnehmen
 	toc=bibliography, % Literaturverzeichnis in das Inhaltsverzeichnis aufnehmen
 	footnotes=multiple, % Trennen von direkt aufeinander folgenden Fußnoten
-	parskip=half % vertikalen Abstand zwischen Absätzen verwenden anstatt horizontale Einrückung von Folgeabsätzen           
+	parskip=half, % vertikalen Abstand zwischen Absätzen verwenden anstatt horizontale Einrückung von Folgeabsätzen
+	numbers=noendperiod % Den letzten Punkt nach einer Nummerierung entfernen (nach DIN 5008)
 ]{scrartcl}
 
 \usepackage[utf8]{inputenc} % muss als erstes eingebunden werden, da Meta/Packages ggfs. Sonderzeichen enthalten


### PR DESCRIPTION
Ich habe hier schonmal einige Anpassungen an die [DIN 5008](http://www.tastschreiben.de/p0400100.htm) bzgl. der Verzeichnisse vorgenommen.
- Inhalts-, Abbildungs-, Tabellen- und Abkürzungsverzeichnis werden jetzt entsprechend der Norm eingerückt.
- Bei Abschnittsüberschriften wurde der letzte Punkt entfernt

Weitere Updates folgen. :)
