### PR TITLE
Gesamte Zeile des Inhaltsverzeichnisses clickbar

### DIFF
--- a/Allgemein/Packages.tex
+++ b/Allgemein/Packages.tex
@@ -90,7 +90,6 @@
     plainpages=false, % zur korrekten Erstellung der Bookmarks
     pdfpagelabels=true, % zur korrekten Erstellung der Bookmarks
     hypertexnames=false, % zur korrekten Erstellung der Bookmarks
-    linktocpage % Seitenzahlen anstatt Text im Inhaltsverzeichnis verlinken
 ]{hyperref}
 % Befehle, die Umlaute ausgeben, führen zu Fehlern, wenn sie hyperref als Optionen übergeben werden
 \hypersetup{

--- a/Projektdokumentation.tex
+++ b/Projektdokumentation.tex
@@ -50,7 +50,12 @@
 \phantomsection
 \pagenumbering{Roman}
 \pdfbookmark[1]{Inhaltsverzeichnis}{inhalt}
+
+\begingroup
+\hypersetup{linkcolor=black}
 \tableofcontents
+\endgroup
+
 \cleardoublepage
 
 \phantomsection


### PR DESCRIPTION
- Linkfarbe im Inhaltsverzeichnis jedoch weiterhin in schwarz 
(Siehe auch: https://latex.org/forum/viewtopic.php?f=4&t=3458#p13513)
- Anpassunge bisher nur in Lyx getestet