### PR TITLE
 scrpage2 wird nicht mehr unterstützt

### DIFF
--- a/Allgemein/Seitenstil.tex
+++ b/Allgemein/Seitenstil.tex
@@ -8,7 +8,7 @@
 	automark, % Kapitelangaben in Kopfzeile automatisch erstellen
 	headsepline, % Trennlinie unter Kopfzeile
 	ilines % Trennlinie linksbündig ausrichten
-]{scrpage2}
+]{scrlayer-scrpage}
 
 % Kopf- und Fußzeilen ----------------------------------------------------------
 \pagestyle{scrheadings}
@@ -67,8 +67,8 @@
 \lstset{emph={square}, emphstyle=\color{red}, emph={[2]root,base}, emphstyle={[2]\color{blue}}}
 
 \counterwithout{footnote}{section} % Fußnoten fortlaufend durchnummerieren
-\setcounter{tocdepth}{\subsubsectionlevel} % im Inhaltsverzeichnis werden die Kapitel bis zum Level der subsubsection übernommen
-\setcounter{secnumdepth}{\subsubsectionlevel} % Kapitel bis zum Level der subsubsection werden nummeriert
+\setcounter{tocdepth}{3} % im Inhaltsverzeichnis werden die Kapitel bis zum Level der subsubsection übernommen
+\setcounter{secnumdepth}{3} % Kapitel bis zum Level der subsubsection werden nummeriert
 
 % Aufzählungen anpassen
 \renewcommand{\labelenumi}{\arabic{enumi}.}


### PR DESCRIPTION
Ich konnte das Template mit Tex Live 2020 nicht mehr kompilieren.

scrpage2 ist nicht mehr Teil aktueller Latex Installationen und wird auch nicht mehr unterstützt. Stattdessen soll scrlayer-scrpage genutzt werden:
https://tex.stackexchange.com/questions/541766/latex-error-file-scrpage2-sty-not-found

Zusätzlich wurde /subsubsectionlevel nicht mehr gefunden. Ich habe das durch feste Zahlenwerte ersetzt, bin aber nicht zufrieden damit. Wenn also jemand eine Alternative hat würde ich mich freuen.