### PR TITLE
Use the same color (black) for all table of something (toc, tof)

### DIFF
--- a/Allgemein/Packages.tex
+++ b/Allgemein/Packages.tex
@@ -71,7 +71,6 @@
     bookmarksopenlevel=1,
     colorlinks=true,
 % diese Farbdefinitionen zeichnen Links im PDF farblich aus
-    linkcolor=AOBlau, % einfache interne Verknüpfungen
     anchorcolor=AOBlau,% Ankertext
     citecolor=AOBlau, % Verweise auf Literaturverzeichniseinträge im Text
     filecolor=AOBlau, % Verknüpfungen, die lokale Dateien öffnen
@@ -90,6 +89,8 @@
     plainpages=false, % zur korrekten Erstellung der Bookmarks
     pdfpagelabels=true, % zur korrekten Erstellung der Bookmarks
     hypertexnames=false, % zur korrekten Erstellung der Bookmarks
+    linkcolor=black,
+    linktoc=all,
 ]{hyperref}
 % Befehle, die Umlaute ausgeben, führen zu Fehlern, wenn sie hyperref als Optionen übergeben werden
 \hypersetup{

--- a/Projektdokumentation.tex
+++ b/Projektdokumentation.tex
@@ -50,11 +50,7 @@
 \phantomsection
 \pagenumbering{Roman}
 \pdfbookmark[1]{Inhaltsverzeichnis}{inhalt}
-
-\begingroup
-\hypersetup{linkcolor=black}
 \tableofcontents
-\endgroup
 
 \cleardoublepage
 


### PR DESCRIPTION
Before, tof was blue while toc was black.

Reverts: 900ee7d7b76d916629db7fedea626acc33ea5e1e
Updates: #10
CC: @pykong
