### PR TITLE
Set Arial as the default font

### DIFF
--- a/Allgemein/Seitenstil.tex
+++ b/Allgemein/Seitenstil.tex
@@ -29,6 +29,13 @@
 \cfoot{}
 \ofoot{\pagemark}
 
+% Arial als Standardschriftart setzen
+\renewcommand*\familydefault{\sfdefault}
+
+% Arial als Schriftart verwenden
+\usepackage{uarial}
+
+
 % Überschriften nach DIN 5008 in einer Fluchtlinie
 % ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Derzeit folgt die Vorlage nicht den Vorgaben der IHK:

> Die Projektdokumentation sollte 12 bis 15 DIN A4-Seiten in üblicher Schriftgröße (z. B. Arial 10 bis 12) beinhalten.

Zu finden unter: https://www.ihk.de/rhein-neckar/ausbildung-weiterbildung/ausbildung/pruefungen-ausbildung/antraege-formulare/dokumentation-betriebliche-projektarbeit-938224#:~:text=Die%20Projektdokumentation%20sollte%2012%20bis,Arial%2010%20bis%2012)%20beinhalten.&text=Deckblatt%2C%20Impressum%2C%20Inhaltsverzeichnis%2C%20Abbildungsverzeichnis,den%2015%20Seiten%20der%20Projektdokumentation.