### PR TITLE
fix: allow for compilation with LuaLaTeX

### DIFF
--- a/Projektdokumentation.tex
+++ b/Projektdokumentation.tex
@@ -16,6 +16,7 @@
 	parskip=half, % vertikalen Abstand zwischen Absätzen verwenden anstatt horizontale Einrückung von Folgeabsätzen
 	numbers=noendperiod % Den letzten Punkt nach einer Nummerierung entfernen (nach DIN 5008)
 ]{scrartcl}
+\usepackage{luatex85}
 \pdfminorversion=5 % erlaubt das Einfügen von pdf-Dateien bis Version 1.7, ohne eine Fehlermeldung zu werfen (keine Garantie für fehlerfreies Einbetten!)
 \usepackage[utf8]{inputenc} % muss als erstes eingebunden werden, da Meta/Packages ggfs. Sonderzeichen enthalten
 


### PR DESCRIPTION
The control sequence \pdfminorversion is undefined in LuaLaTeX.
According to https://tex.stackexchange.com/a/374993 there's a shim to emulate it.